### PR TITLE
fix: skip installing packages when nothing to install

### DIFF
--- a/src/deno/install.sh
+++ b/src/deno/install.sh
@@ -61,7 +61,7 @@ EXE="${BIN_DIR}/deno"
 
 # Install global packages if specified
 # See https://docs.deno.com/runtime/reference/cli/install/#global-installation
-if [ "${#PACKAGES[@]}" -gt 0 ]; then
+if [ -n "${PACKAGES}" ]; then
     echo "Installing global packages..."
     su "${_REMOTE_USER}" -c "$EXE install --global --allow-net --allow-read ${PACKAGES}"
 fi

--- a/src/deno/install.sh
+++ b/src/deno/install.sh
@@ -63,6 +63,8 @@ EXE="${BIN_DIR}/deno"
 # See https://docs.deno.com/runtime/reference/cli/install/#global-installation
 if [ -n "${PACKAGES}" ]; then
     echo "Installing global packages..."
+    # Replace commas to spaces.
+    PACKAGES=${PACKAGES//,/ }
     su "${_REMOTE_USER}" -c "$EXE install --global --allow-net --allow-read ${PACKAGES}"
 fi
 


### PR DESCRIPTION
this changeset is to fix the issues related to installing packages.

- treat packages as string instead of array of strings https://containers.dev/implementors/features/#options-property
- replace commas (`,`) to spaces (` `)